### PR TITLE
Added a wrapper for the /sources API method

### DIFF
--- a/src/DataSources.js
+++ b/src/DataSources.js
@@ -1,0 +1,25 @@
+Openphacts.DataSources = function DataSources(baseURL, appID, appKey) {
+        this.baseURL = baseURL;
+        this.appID = appID;
+        this.appKey = appKey;
+}
+
+Openphacts.DataSources.prototype.getSources = function(callback) {
+        var sourcesQuery = $.ajax({
+                url: this.baseURL + '/sources',
+                dataType: 'json',
+                cache: true,
+                data: {
+                        _format: "json",
+                        app_id: this.appID,
+                        app_key: this.appKey
+                },
+                success: function(response, status, request) {
+                        callback.call(this, true, request.status, response.result.primaryTopic);
+                },
+                error: function(request, status, error) {
+                        callback.call(this, false, request.status);
+                }
+        });
+}
+


### PR DESCRIPTION
Added code to wrap the "data sources" API method.

Ian, how do I annotate this code to have it show up at http://openphacts.github.io/ops.js/ ?
